### PR TITLE
Mermaid 미리보기 렌더링 안정화

### DIFF
--- a/components/MermaidPreview.tsx
+++ b/components/MermaidPreview.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { Theme } from "@/libs/presets";
+import type { Mermaid as MermaidRuntime, MermaidConfig } from "mermaid";
 
 type Props = {
   code: string;
@@ -11,9 +12,6 @@ type Props = {
   onSVG: (svg: string) => void;
   autoFit?: boolean;
 };
-
-type MermaidRuntime = typeof import("mermaid").default;
-type MermaidConfig = Parameters<MermaidRuntime["initialize"]>[0];
 
 const FIXED_PREVIEW_HEIGHT_PX = 500;
 const EPS = 0.005;

--- a/components/MermaidPreview.tsx
+++ b/components/MermaidPreview.tsx
@@ -12,15 +12,8 @@ type Props = {
   autoFit?: boolean;
 };
 
-type MermaidRuntime = {
-  initialize: (options: {
-    startOnLoad: boolean;
-    theme: string;
-    securityLevel: string;
-    fontFamily: string;
-  }) => void;
-  render: (id: string, code: string) => Promise<{ svg: string }>;
-};
+type MermaidRuntime = typeof import("mermaid").default;
+type MermaidConfig = Parameters<MermaidRuntime["initialize"]>[0];
 
 const FIXED_PREVIEW_HEIGHT_PX = 500;
 const EPS = 0.005;
@@ -85,6 +78,8 @@ export default function MermaidPreview({
   const mermaidRef = useRef<MermaidRuntime | null>(null);
   const renderSeqRef = useRef(0);
   const fitRafRef = useRef<number | null>(null);
+  const resolvedTheme: MermaidConfig["theme"] =
+    theme === "custom" ? "base" : theme;
 
   const setFitScaleSafe = useCallback((nextScale: number) => {
     if (Math.abs(fitScaleRef.current - nextScale) <= EPS) {
@@ -117,7 +112,7 @@ export default function MermaidPreview({
         }
         mermaid.initialize({
           startOnLoad: false,
-          theme: theme === "custom" ? "base" : theme,
+          theme: resolvedTheme,
           securityLevel: "strict",
           fontFamily: "Inter, Pretendard, system-ui, sans-serif",
         });
@@ -138,7 +133,7 @@ export default function MermaidPreview({
     return () => {
       cancelled = true;
     };
-  }, [code, theme, onSVG]);
+  }, [code, onSVG, resolvedTheme]);
 
   useEffect(() => {
     const container = svgContainerRef.current;

--- a/components/MermaidPreview.tsx
+++ b/components/MermaidPreview.tsx
@@ -1,5 +1,6 @@
 "use client";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { Theme } from "@/libs/presets";
 
 type Props = {
@@ -11,17 +12,61 @@ type Props = {
   autoFit?: boolean;
 };
 
+type MermaidRuntime = {
+  initialize: (options: {
+    startOnLoad: boolean;
+    theme: string;
+    securityLevel: string;
+    fontFamily: string;
+  }) => void;
+  render: (id: string, code: string) => Promise<{ svg: string }>;
+};
+
 const FIXED_PREVIEW_HEIGHT_PX = 500;
 const EPS = 0.005;
+const FIT_PADDING_PX = 16;
+const MIN_FIT_SCALE = 0.4;
+const MAX_FIT_SCALE = 1.2;
 
-// 노드/엣지 카운트
-function countNodes(code: string): number {
-  const m = code.match(/(\[.*?\]|\{.*?\}|\(\(.*?\)\))/g);
-  return m ? m.length : 0;
+const ERROR_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="420" height="88" viewBox="0 0 420 88" role="img" aria-label="Mermaid parse error">
+  <rect width="100%" height="100%" rx="12" fill="#fee2e2" />
+  <text x="18" y="34" font-size="16" font-weight="700" fill="#991b1b">Mermaid Parse Error</text>
+  <text x="18" y="58" font-size="13" fill="#7f1d1d">Check the diagram syntax and try again.</text>
+</svg>`;
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(max, Math.max(min, value));
 }
-function countEdges(code: string): number {
-  const m = code.match(/-->|-\.->|===|--/g);
-  return m ? m.length : 0;
+
+function parseSvgLength(value: string | null) {
+  if (!value) return 0;
+  const parsed = Number.parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function parseSvgIntrinsicSize(svgString: string) {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(svgString, "image/svg+xml");
+  const svg = doc.documentElement;
+
+  const viewBox = svg.getAttribute("viewBox");
+  if (viewBox) {
+    const parts = viewBox
+      .trim()
+      .split(/[\s,]+/)
+      .map((part) => Number.parseFloat(part));
+    if (parts.length === 4 && parts[2] > 0 && parts[3] > 0) {
+      return { width: parts[2], height: parts[3] };
+    }
+  }
+
+  const width = parseSvgLength(svg.getAttribute("width"));
+  const height = parseSvgLength(svg.getAttribute("height"));
+  if (width > 0 && height > 0) {
+    return { width, height };
+  }
+
+  return null;
 }
 
 export default function MermaidPreview({
@@ -37,153 +82,147 @@ export default function MermaidPreview({
   const fitScaleRef = useRef<number>(scale);
   const wrapRef = useRef<HTMLDivElement>(null);
   const svgContainerRef = useRef<HTMLDivElement>(null);
-  const mermaidRef = useRef<any>(null);
+  const mermaidRef = useRef<MermaidRuntime | null>(null);
+  const renderSeqRef = useRef(0);
+  const fitRafRef = useRef<number | null>(null);
 
-  // ✅ setFitScaleSafe를 useCallback으로 안정화
-  const setFitScaleSafe = useCallback((v: number) => {
-    fitScaleRef.current = v;
-    setFitScale(v);
-  }, []); // setState 세터는 안정적이라 deps 비워도 됨
+  const setFitScaleSafe = useCallback((nextScale: number) => {
+    if (Math.abs(fitScaleRef.current - nextScale) <= EPS) {
+      return;
+    }
+    fitScaleRef.current = nextScale;
+    setFitScale(nextScale);
+  }, []);
 
-  // autoFit 끄면 외부 scale에 즉시 동기화
   useEffect(() => {
-    if (!autoFit && Math.abs(fitScaleRef.current - scale) > EPS) {
+    if (!autoFit) {
       setFitScaleSafe(scale);
     }
-  }, [autoFit, scale, setFitScaleSafe]); // ✅ 의존성 추가
+  }, [autoFit, scale, setFitScaleSafe]);
 
-  // 1) Mermaid 렌더
   useEffect(() => {
     let cancelled = false;
-    (async () => {
-      if (!mermaidRef.current) {
-        const mod = await import("mermaid");
-        mermaidRef.current = mod.default ?? mod;
-      }
-      const mermaid = mermaidRef.current;
-      mermaid.initialize({
-        startOnLoad: false,
-        theme: theme === "custom" ? "base" : theme,
-        securityLevel: "strict",
-        fontFamily: "Inter, Pretendard, system-ui, sans-serif",
-      });
+    const renderId = ++renderSeqRef.current;
 
+    (async () => {
       try {
-        const { svg } = await mermaid.render(`m-${Date.now()}`, code);
-        if (!cancelled) {
+        if (!mermaidRef.current) {
+          const mod = await import("mermaid");
+          mermaidRef.current = mod.default ?? mod;
+        }
+
+        const mermaid = mermaidRef.current;
+        if (!mermaid) {
+          throw new Error("Mermaid runtime was not initialized.");
+        }
+        mermaid.initialize({
+          startOnLoad: false,
+          theme: theme === "custom" ? "base" : theme,
+          securityLevel: "strict",
+          fontFamily: "Inter, Pretendard, system-ui, sans-serif",
+        });
+
+        const { svg } = await mermaid.render(`m-${renderId}`, code);
+        if (!cancelled && renderSeqRef.current === renderId) {
           setRawSvg(svg);
           onSVG(svg);
         }
       } catch {
-        if (!cancelled) {
-          const err = `<svg xmlns="http://www.w3.org/2000/svg" width="420" height="60">
-            <rect width="100%" height="100%" fill="#fee2e2"/>
-            <text x="12" y="36" font-size="14" fill="#b91c1c">Mermaid Parse Error</text>
-          </svg>`;
-          setRawSvg(err);
-          onSVG(err);
+        if (!cancelled && renderSeqRef.current === renderId) {
+          setRawSvg(ERROR_SVG);
+          onSVG(ERROR_SVG);
         }
       }
     })();
+
     return () => {
       cancelled = true;
     };
   }, [code, theme, onSVG]);
 
-  // 2) SVG 주입
   useEffect(() => {
-    if (svgContainerRef.current) {
-      svgContainerRef.current.innerHTML = rawSvg;
+    const container = svgContainerRef.current;
+    if (!container) {
+      return;
     }
+    container.innerHTML = rawSvg;
   }, [rawSvg]);
 
-  // 3) 오토핏 계산
-  const computeAndSetFit = useCallback(() => {
-    if (!autoFit || !rawSvg || !wrapRef.current) {
-      if (Math.abs(fitScaleRef.current - scale) > EPS) setFitScaleSafe(scale);
-      return;
+  const scheduleFit = useCallback(() => {
+    if (fitRafRef.current !== null) {
+      cancelAnimationFrame(fitRafRef.current);
     }
-    const wrap = wrapRef.current;
 
-    // 패딩 제거한 실사용 영역
-    const cs = getComputedStyle(wrap);
-    const padX =
-      parseFloat(cs.paddingLeft || "0") + parseFloat(cs.paddingRight || "0");
-    const padY =
-      parseFloat(cs.paddingTop || "0") + parseFloat(cs.paddingBottom || "0");
-    const usableW = Math.max(0, wrap.clientWidth - padX);
-    const usableH = Math.max(0, wrap.clientHeight - padY);
-    if (!usableW || !usableH) return;
+    fitRafRef.current = requestAnimationFrame(() => {
+      fitRafRef.current = null;
 
-    const vb = rawSvg.match(/viewBox\s*=\s*"([\d.\s-]+)"/i);
-    let svgW = 0,
-      svgH = 0;
-    if (vb?.[1]) {
-      const p = vb[1].trim().split(/\s+/).map(Number);
-      if (p.length === 4) {
-        svgW = p[2];
-        svgH = p[3];
+      const wrap = wrapRef.current;
+      if (!wrap || !rawSvg) {
+        setFitScaleSafe(scale);
+        return;
       }
-    }
-    if (!svgW || !svgH) {
-      if (Math.abs(fitScaleRef.current - scale) > EPS) setFitScaleSafe(scale);
-      return;
-    }
 
-    const nodes = countNodes(code);
-    const edges = countEdges(code);
+      const size = parseSvgIntrinsicSize(rawSvg);
+      if (!autoFit || !size) {
+        setFitScaleSafe(scale);
+        return;
+      }
 
-    const SAFE_MARGIN = 1;
-    const base = Math.min(
-      (usableW - SAFE_MARGIN) / svgW,
-      (usableH - SAFE_MARGIN) / svgH
-    );
+      const cs = getComputedStyle(wrap);
+      const padX =
+        Number.parseFloat(cs.paddingLeft || "0") +
+        Number.parseFloat(cs.paddingRight || "0");
+      const padY =
+        Number.parseFloat(cs.paddingTop || "0") +
+        Number.parseFloat(cs.paddingBottom || "0");
 
-    const MIN_FIT_SCALE = 0.5;
-    const MAX_FIT_SCALE = 1.2;
+      const usableW = Math.max(0, wrap.clientWidth - padX - FIT_PADDING_PX);
+      const usableH = Math.max(0, wrap.clientHeight - padY - FIT_PADDING_PX);
+      if (!usableW || !usableH) {
+        return;
+      }
 
-    let s: number;
-    if (nodes <= 4 && edges <= 4) s = Math.min(base, 1) * 0.95;
-    else if (nodes <= 12) s = base * 0.95;
-    else if (nodes <= 60) s = base * 0.9;
-    else s = base * 0.85;
-
-    const clamped = Math.min(
-      MAX_FIT_SCALE,
-      Math.max(MIN_FIT_SCALE, Number(s.toFixed(3)))
-    );
-
-    if (Math.abs(clamped - fitScaleRef.current) > EPS) {
-      setFitScaleSafe(clamped);
-    }
-  }, [autoFit, rawSvg, scale, code, setFitScaleSafe]); // ✅ 의존성 추가
-
-  // 4) 초기/리사이즈 시 오토핏 (raf 디바운스)
-  useEffect(() => {
-    const el = wrapRef.current;
-    if (!el) return;
-
-    let raf = 0;
-    const ro = new ResizeObserver(() => {
-      cancelAnimationFrame(raf);
-      raf = requestAnimationFrame(computeAndSetFit);
+      const baseScale = Math.min(usableW / size.width, usableH / size.height);
+      const nextScale = clamp(
+        Number((baseScale * 0.96).toFixed(3)),
+        MIN_FIT_SCALE,
+        MAX_FIT_SCALE,
+      );
+      setFitScaleSafe(nextScale);
     });
-    ro.observe(el);
-    computeAndSetFit();
+  }, [autoFit, rawSvg, scale, setFitScaleSafe]);
+
+  useEffect(() => {
+    const wrap = wrapRef.current;
+    if (!wrap) return;
+
+    let cancelled = false;
+    const ro = new ResizeObserver(() => {
+      if (!cancelled) {
+        scheduleFit();
+      }
+    });
+
+    ro.observe(wrap);
+    const svg = svgContainerRef.current?.querySelector("svg");
+    if (svg) {
+      ro.observe(svg);
+    }
+
+    scheduleFit();
 
     return () => {
-      cancelAnimationFrame(raf);
+      cancelled = true;
+      if (fitRafRef.current !== null) {
+        cancelAnimationFrame(fitRafRef.current);
+        fitRafRef.current = null;
+      }
       ro.disconnect();
     };
-  }, [computeAndSetFit]);
-
-  const appliedScale = useMemo(
-    () => (autoFit ? fitScale : scale),
-    [autoFit, fitScale, scale]
-  );
+  }, [scheduleFit]);
 
   const handleFitToView = () => {
-    computeAndSetFit();
+    scheduleFit();
     const el = wrapRef.current;
     if (el) el.scrollTo({ top: 0, left: 0, behavior: "smooth" });
   };
@@ -201,26 +240,24 @@ export default function MermaidPreview({
       onWheelCapture={(e) => e.stopPropagation()}
       aria-label="Mermaid diagram viewport"
     >
-      {/* ⛶ 버튼 */}
       <div className="sticky top-2 left-0 right-0 z-30">
         <div className="flex justify-end pr-2 pointer-events-none">
           <button
             type="button"
             onClick={handleFitToView}
             className="pointer-events-auto rounded-md bg-white/80 border border-slate-200 px-2 py-1 text-sm shadow-sm hover:bg-white active:scale-[0.97] transition"
-            title="전체 보기"
-            aria-label="전체 보기"
+            title="Fit to view"
+            aria-label="Fit to view"
           >
-            ⛶
+            Fit
           </button>
         </div>
       </div>
 
-      {/* Preview 콘텐츠 */}
       <div
         className="flex items-start justify-center"
         style={{
-          transform: `scale(${appliedScale})`,
+          transform: `scale(${autoFit ? fitScale : scale})`,
           transformOrigin: "top left",
           padding: 8,
         }}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack",
+    "dev": "next dev --webpack",
     "build": "next build --turbopack",
     "start": "next start",
     "lint": "biome check",


### PR DESCRIPTION
## 변경 요약
Mermaid 미리보기 렌더링 경로를 안정화했습니다.
빠르게 코드를 수정할 때 이전 render 결과가 뒤섞이지 않도록 처리했고, 파싱 오류가 나면 예측 가능한 오류 SVG를 보여주도록 정리했습니다.
또한 fit-to-view 계산이 큰 SVG나 리사이즈 상황에서도 과도하게 흔들리지 않도록 보정했습니다.
개발 서버에서는 Turbopack 충돌을 피하기 위해 로컬 `dev` 스크립트를 webpack 경로로 전환했습니다.

## 직접 테스트 가능 여부
가능

## 확인한 사항
| 항목 | 상태 |
| --- | --- |
| `npm run build` | 통과 |
| PR 브랜치 `npm run dev` | 로컬 개발 서버 기준 확인 대상 |

## 테스트 시나리오
1. 정상 다이어그램 렌더링
샘플 Mermaid 코드를 입력합니다.
코드를 몇 번 빠르게 수정한 뒤 잠시 멈춥니다.
미리보기 영역이 마지막 입력 상태 기준으로 안정적으로 렌더링되는지 확인합니다.
기대 결과:
- 이전 렌더 결과가 섞이거나 깜빡이며 남지 않습니다.
- 마지막 입력 상태의 다이어그램만 표시됩니다.

2. 파싱 오류 표시
아래처럼 문법 오류가 있는 Mermaid 코드를 입력합니다.

```text
graph TD
  A[Start] --> B[
```

기대 결과:
- 브라우저가 깨지지 않고 오류 안내 SVG가 표시됩니다.
- 오류 상태에서 다시 정상 코드로 바꾸면 정상 렌더링으로 복구됩니다.

3. Fit 버튼 / 리사이즈 확인
가로로 긴 다이어그램이나 세로로 긴 다이어그램을 입력한 뒤, 창 크기를 줄이거나 늘립니다.
그 다음 미리보기 우측 상단의 `Fit` 버튼을 눌러 봅니다.
기대 결과:
- 다이어그램이 미리보기 영역 안에 다시 맞춰집니다.
- 과도하게 확대되거나 축소된 상태로 고정되지 않습니다.

4. Theme 변경 확인
`Theme`를 `default`, `dark`, `forest` 등으로 변경합니다.
각 테마에서 다이어그램이 정상적으로 다시 그려지는지 확인합니다.
기대 결과:
- 테마 변경 직후 해당 theme 기준으로 다시 렌더링됩니다.
- 렌더링 실패나 이전 테마 잔상이 남지 않습니다.

## 참고
이 PR은 미리보기 렌더링 안정화가 목적이라 별도의 성능 측정표는 포함하지 않았습니다.
개발 환경에서 직접 확인할 수 있는 시나리오 위주로 정리했습니다.