### PR TITLE
내보내기 파이프라인 안정화

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -34,7 +34,7 @@ export default function Page() {
 
   const shareState = useMemo(
     () => ({ code, theme, bg, scale, exportScale, editorMode }),
-    [code, theme, bg, scale, exportScale, editorMode]
+    [code, theme, bg, scale, exportScale, editorMode],
   );
 
   return (
@@ -107,6 +107,7 @@ export default function Page() {
             {/* Export Controls (기존 위치 유지, 중앙선 정렬) */}
             <div className="ml-auto self-center">
               <ExportButtons
+                code={code}
                 svg={svg}
                 bg={bg}
                 exportScale={exportScale}

--- a/components/ExportButtons.tsx
+++ b/components/ExportButtons.tsx
@@ -12,11 +12,13 @@ type ExportFormat = "svg" | "png" | "jpg";
 type AspectOption = "original" | AspectPreset;
 
 export default function ExportButtons({
+  code,
   svg,
   bg,
   exportScale,
   className = "",
 }: {
+  code: string;
   svg: string;
   bg: string;
   exportScale: number;
@@ -25,11 +27,13 @@ export default function ExportButtons({
   const [format, setFormat] = useState<ExportFormat>("png");
   const [aspect, setAspect] = useState<AspectOption>("original");
   const [filename, setFilename] = useState("diagram");
-  const hasDiagram = svg.trim().length > 0;
-  const isAspectDisabled = format === "svg" || !hasDiagram;
+  const hasExportableDiagram = code.trim().length > 0 && svg.trim().length > 0;
+  const isAspectDisabled = format === "svg" || !hasExportableDiagram;
 
   const hint = useMemo(() => {
-    if (!hasDiagram) return "Paste Mermaid code to enable export.";
+    if (!hasExportableDiagram) {
+      return "Render a valid Mermaid diagram to enable export.";
+    }
     if (format === "svg") {
       return "SVG export stays vector-based and ignores aspect presets.";
     }
@@ -37,10 +41,10 @@ export default function ExportButtons({
       return "Exports at the diagram's original aspect ratio.";
     }
     return `Exports on a ${aspect} canvas and centers the diagram.`;
-  }, [aspect, format, hasDiagram]);
+  }, [aspect, format, hasExportableDiagram]);
 
   const handleExport = () => {
-    if (!hasDiagram) return;
+    if (!hasExportableDiagram) return;
 
     if (format === "svg") {
       downloadSVG(svg, filename);
@@ -93,8 +97,17 @@ export default function ExportButtons({
           id="format"
           value={format}
           onChange={(e) => setFormat(e.target.value as ExportFormat)}
-          className="rounded-lg border border-slate-200 px-2 h-8 text-sm bg-white outline-none focus:ring-2 focus:ring-slate-300"
+          disabled={!hasExportableDiagram}
+          className={[
+            "rounded-lg border border-slate-200 px-2 h-8 text-sm bg-white outline-none focus:ring-2 focus:ring-slate-300",
+            !hasExportableDiagram ? "cursor-not-allowed opacity-60" : "",
+          ].join(" ")}
           aria-label="Export format"
+          title={
+            hasExportableDiagram
+              ? "Choose an export format"
+              : "Render a valid Mermaid diagram before choosing an export format"
+          }
         >
           <option value="png">PNG</option>
           <option value="jpg">JPG</option>
@@ -124,12 +137,16 @@ export default function ExportButtons({
         <button
           type="button"
           onClick={handleExport}
-          disabled={!hasDiagram}
-          title={hasDiagram ? "Export diagram" : "Paste Mermaid code before exporting"}
-          aria-disabled={!hasDiagram}
+          disabled={!hasExportableDiagram}
+          title={
+            hasExportableDiagram
+              ? "Export diagram"
+              : "Render a valid Mermaid diagram before exporting"
+          }
+          aria-disabled={!hasExportableDiagram}
           className={[
             "ml-1 rounded-lg px-3 h-8 text-sm font-semibold text-white shadow-sm transition",
-            hasDiagram
+            hasExportableDiagram
               ? "bg-slate-900 hover:bg-slate-800 active:scale-[0.99] focus:outline-none focus:ring-2 focus:ring-slate-300"
               : "cursor-not-allowed bg-slate-400 opacity-70",
           ].join(" ")}

--- a/components/ExportButtons.tsx
+++ b/components/ExportButtons.tsx
@@ -1,4 +1,5 @@
 "use client";
+
 import { useMemo, useState } from "react";
 import {
   downloadRasterForAspect,
@@ -24,52 +25,55 @@ export default function ExportButtons({
   const [format, setFormat] = useState<ExportFormat>("png");
   const [aspect, setAspect] = useState<AspectOption>("original");
   const [filename, setFilename] = useState("diagram");
+  const hasDiagram = svg.trim().length > 0;
+  const isAspectDisabled = format === "svg" || !hasDiagram;
 
   const hint = useMemo(() => {
-    if (format === "svg")
-      return "SVG는 벡터 포맷이라 비율/배경 개념이 없습니다.";
-    if (aspect === "original") return "원본 비율·배율로 내보냅니다.";
-    return `프리셋 비율(${aspect})로 캔버스를 맞춰 내보냅니다.`;
-  }, [format, aspect]);
+    if (!hasDiagram) return "Paste Mermaid code to enable export.";
+    if (format === "svg") {
+      return "SVG export stays vector-based and ignores aspect presets.";
+    }
+    if (aspect === "original") {
+      return "Exports at the diagram's original aspect ratio.";
+    }
+    return `Exports on a ${aspect} canvas and centers the diagram.`;
+  }, [aspect, format, hasDiagram]);
 
   const handleExport = () => {
-    if (!svg) return;
+    if (!hasDiagram) return;
 
     if (format === "svg") {
-      downloadSVG(svg, `${filename}.svg`);
+      downloadSVG(svg, filename);
       return;
     }
+
     const mime = format === "png" ? "image/png" : "image/jpeg";
-    const ext = format === "png" ? "png" : "jpg";
 
     if (aspect === "original") {
-      downloadRasterFromSVG(svg, mime, `${filename}.${ext}`, exportScale, bg);
-    } else {
-      downloadRasterForAspect(svg, `${filename}.${ext}`, mime, {
-        aspect: ASPECT_MAP[aspect],
-        scale: exportScale,
-        background: bg,
-      });
+      downloadRasterFromSVG(svg, mime, filename, exportScale, bg);
+      return;
     }
-  };
 
-  const isAspectDisabled = format === "svg";
+    downloadRasterForAspect(svg, filename, mime, {
+      aspect: ASPECT_MAP[aspect],
+      scale: exportScale,
+      background: bg,
+    });
+  };
 
   return (
     <section
       className={["min-w-0", className].join(" ")}
       aria-label="Export toolbar"
     >
-      {/* ── 툴바 (한 줄) ───────────────────────────────────────────── */}
       <div
         className={[
           "flex items-center gap-2 rounded-xl border border-slate-200/80 bg-white/70",
           "backdrop-blur px-2 py-1 shadow-sm whitespace-nowrap overflow-x-auto",
         ].join(" ")}
       >
-        {/* 파일명 */}
         <label htmlFor="filename" className="sr-only">
-          파일명
+          File name
         </label>
         <input
           id="filename"
@@ -80,11 +84,10 @@ export default function ExportButtons({
           spellCheck={false}
         />
 
-        <span className="text-slate-300 select-none">•</span>
+        <span className="text-slate-300 select-none">/</span>
 
-        {/* 포맷 */}
         <label htmlFor="format" className="sr-only">
-          포맷
+          Export format
         </label>
         <select
           id="format"
@@ -98,9 +101,8 @@ export default function ExportButtons({
           <option value="svg">SVG</option>
         </select>
 
-        {/* 비율 */}
         <label htmlFor="aspect" className="sr-only">
-          비율
+          Aspect ratio
         </label>
         <select
           id="aspect"
@@ -113,23 +115,29 @@ export default function ExportButtons({
           ].join(" ")}
           aria-label="Aspect ratio preset"
         >
-          <option value="original">원본</option>
+          <option value="original">Original</option>
           <option value="3:2">3:2</option>
           <option value="4:3">4:3</option>
           <option value="16:9">16:9</option>
         </select>
 
-        {/* Export 버튼 */}
         <button
           type="button"
           onClick={handleExport}
-          className="ml-1 rounded-lg px-3 h-8 text-sm font-semibold bg-slate-900 text-white hover:bg-slate-800 active:scale-[0.99] focus:outline-none focus:ring-2 focus:ring-slate-300 transition shadow-sm"
+          disabled={!hasDiagram}
+          title={hasDiagram ? "Export diagram" : "Paste Mermaid code before exporting"}
+          aria-disabled={!hasDiagram}
+          className={[
+            "ml-1 rounded-lg px-3 h-8 text-sm font-semibold text-white shadow-sm transition",
+            hasDiagram
+              ? "bg-slate-900 hover:bg-slate-800 active:scale-[0.99] focus:outline-none focus:ring-2 focus:ring-slate-300"
+              : "cursor-not-allowed bg-slate-400 opacity-70",
+          ].join(" ")}
         >
           Export
         </button>
       </div>
 
-      {/* ── 상시 노출 힌트 (한 줄, 말줄임) ─────────────────────────── */}
       <p
         className="mt-1 text-[11px] leading-tight text-slate-500 whitespace-nowrap overflow-hidden text-ellipsis"
         aria-live="polite"

--- a/components/MermaidPreview.tsx
+++ b/components/MermaidPreview.tsx
@@ -14,6 +14,35 @@ type Props = {
 const FIXED_PREVIEW_HEIGHT_PX = 500;
 const EPS = 0.005;
 
+function buildStatusSvg({
+  fill,
+  message,
+  textFill,
+}: {
+  fill: string;
+  message: string;
+  textFill: string;
+}) {
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="420" height="60" viewBox="0 0 420 60" role="img" aria-label="${message}">
+    <rect width="420" height="60" rx="12" fill="${fill}"/>
+    <text x="16" y="36" font-size="14" font-family="Inter, Pretendard, system-ui, sans-serif" fill="${textFill}">
+      ${message}
+    </text>
+  </svg>`;
+}
+
+const EMPTY_PREVIEW_SVG = buildStatusSvg({
+  fill: "#f8fafc",
+  message: "Enter Mermaid code to preview.",
+  textFill: "#475569",
+});
+
+const ERROR_PREVIEW_SVG = buildStatusSvg({
+  fill: "#fee2e2",
+  message: "Mermaid Parse Error",
+  textFill: "#b91c1c",
+});
+
 // 노드/엣지 카운트
 function countNodes(code: string): number {
   const m = code.match(/(\[.*?\]|\{.*?\}|\(\(.*?\)\))/g);
@@ -55,7 +84,16 @@ export default function MermaidPreview({
   // 1) Mermaid 렌더
   useEffect(() => {
     let cancelled = false;
+    onSVG("");
     (async () => {
+      const trimmedCode = code.trim();
+      if (!trimmedCode) {
+        if (!cancelled) {
+          setRawSvg(EMPTY_PREVIEW_SVG);
+        }
+        return;
+      }
+
       if (!mermaidRef.current) {
         const mod = await import("mermaid");
         mermaidRef.current = mod.default ?? mod;
@@ -69,19 +107,15 @@ export default function MermaidPreview({
       });
 
       try {
-        const { svg } = await mermaid.render(`m-${Date.now()}`, code);
+        const { svg } = await mermaid.render(`m-${Date.now()}`, trimmedCode);
         if (!cancelled) {
-          setRawSvg(svg);
-          onSVG(svg);
+          const exportableSvg = svg.trim();
+          setRawSvg(exportableSvg);
+          onSVG(exportableSvg);
         }
       } catch {
         if (!cancelled) {
-          const err = `<svg xmlns="http://www.w3.org/2000/svg" width="420" height="60">
-            <rect width="100%" height="100%" fill="#fee2e2"/>
-            <text x="12" y="36" font-size="14" fill="#b91c1c">Mermaid Parse Error</text>
-          </svg>`;
-          setRawSvg(err);
-          onSVG(err);
+          setRawSvg(ERROR_PREVIEW_SVG);
         }
       }
     })();
@@ -136,7 +170,7 @@ export default function MermaidPreview({
     const SAFE_MARGIN = 1;
     const base = Math.min(
       (usableW - SAFE_MARGIN) / svgW,
-      (usableH - SAFE_MARGIN) / svgH
+      (usableH - SAFE_MARGIN) / svgH,
     );
 
     const MIN_FIT_SCALE = 0.5;
@@ -150,7 +184,7 @@ export default function MermaidPreview({
 
     const clamped = Math.min(
       MAX_FIT_SCALE,
-      Math.max(MIN_FIT_SCALE, Number(s.toFixed(3)))
+      Math.max(MIN_FIT_SCALE, Number(s.toFixed(3))),
     );
 
     if (Math.abs(clamped - fitScaleRef.current) > EPS) {
@@ -179,7 +213,7 @@ export default function MermaidPreview({
 
   const appliedScale = useMemo(
     () => (autoFit ? fitScale : scale),
-    [autoFit, fitScale, scale]
+    [autoFit, fitScale, scale],
   );
 
   const handleFitToView = () => {

--- a/libs/svgExport.ts
+++ b/libs/svgExport.ts
@@ -1,28 +1,27 @@
 // libs/svgExport.ts
 import { Canvg } from "canvg";
 
-/** SVG 원본 저장 */
+/** Export SVG as-is. */
 export async function downloadSVG(svg: string, filename = "diagram.svg") {
   const blob = new Blob([svg], { type: "image/svg+xml;charset=utf-8" });
-  trigger(blob, filename);
+  trigger(blob, buildExportFilename(filename, "svg"));
 }
 
-/** ✅ 프리셋용: 목표 가로/세로 비(Aspect, W/H)를 최소로 보장해 Contain 중앙 배치 */
+/** Export a raster image while fitting the diagram into a wider target aspect ratio. */
 export async function downloadRasterForAspect(
   svg: string,
   filename: string,
   type: "image/png" | "image/jpeg",
   opts: {
-    aspect: number; // 목표 최소 W/H (예: 3:2 → 1.5, 4:3 → 1.3333, 16:9 → 1.7777)
-    scale?: number; // 기본 2
-    background?: string; // 여백/배경색 (프리뷰 bg 전달)
+    aspect: number;
+    scale?: number;
+    background?: string;
   }
 ) {
-  const scale = opts.scale ?? 2;
+  const scale = normalizeScale(opts.scale, 2);
   const bg = opts.background ?? "#ffffff";
-  const targetAspect = Math.max(0.1, opts.aspect);
+  const targetAspect = normalizeAspect(opts.aspect, 1);
 
-  // 1) 텍스트 보존 + 라벨 배경 선합성(pre-compose)
   const textified = foreignObjectToCenteredText(svg, {
     canvasBg: bg,
     precompose: true,
@@ -34,50 +33,51 @@ export async function downloadRasterForAspect(
 
   await waitFontsForSvg(normalized);
 
-  // 2) 최종 캔버스 크기 결정: 현재 W/H가 목표보다 작으면 가로폭을 늘려 여백 추가
   const curAspect = baseW / baseH;
   const dstW =
     curAspect < targetAspect ? Math.round(baseH * targetAspect) : baseW;
   const dstH = baseH;
 
-  // 3) 네이티브 렌더 우선
   try {
     const blob = new Blob([normalized], {
       type: "image/svg+xml;charset=utf-8",
     });
     const url = URL.createObjectURL(blob);
 
-    const { canvas, ctx } = makeCanvas(dstW, dstH);
-    ctx.fillStyle = bg;
-    ctx.fillRect(0, 0, dstW, dstH);
+    try {
+      const { canvas, ctx } = makeCanvas(dstW, dstH);
+      ctx.fillStyle = bg;
+      ctx.fillRect(0, 0, dstW, dstH);
 
-    const img = await loadImage(url);
-    const vb = getViewBox(normalized) ?? {
-      x: 0,
-      y: 0,
-      w: src.width,
-      h: src.height,
-    };
-    const { dx, dy, dw, dh } = fitContain(vb.w, vb.h, dstW, dstH);
-    ctx.drawImage(
-      img,
-      Math.round(dx),
-      Math.round(dy),
-      Math.round(dw),
-      Math.round(dh)
-    );
-    queueMicrotask(() => URL.revokeObjectURL(url));
+      const img = await loadImage(url);
+      const vb = getViewBox(normalized) ?? {
+        x: 0,
+        y: 0,
+        w: src.width,
+        h: src.height,
+      };
+      const { dx, dy, dw, dh } = fitContain(vb.w, vb.h, dstW, dstH);
+      if (dw > 0 && dh > 0) {
+        ctx.drawImage(
+          img,
+          Math.round(dx),
+          Math.round(dy),
+          Math.round(dw),
+          Math.round(dh)
+        );
+      }
 
-    const out = await canvasToBlob(canvas, type);
-    if (out) trigger(out, filename);
-    return;
+      const out = await canvasToBlob(canvas, type);
+      if (out) trigger(out, buildExportFilename(filename, fileExtension(type)));
+      return;
+    } finally {
+      URL.revokeObjectURL(url);
+    }
   } catch {
-    // 4) canvg 폴백
     const { canvas, ctx } = makeCanvas(dstW, dstH);
     ctx.fillStyle = bg;
     ctx.fillRect(0, 0, dstW, dstH);
 
-    // 오프스크린 → Contain 배치
     const off = document.createElement("canvas");
     off.width = baseW;
     off.height = baseH;
@@ -91,26 +91,22 @@ export async function downloadRasterForAspect(
     await v.render();
 
     const { dx, dy, dw, dh } = fitContain(off.width, off.height, dstW, dstH);
-    ctx.drawImage(
-      off,
-      Math.round(dx),
-      Math.round(dy),
-      Math.round(dw),
-      Math.round(dh)
-    );
+    if (dw > 0 && dh > 0) {
+      ctx.drawImage(
+        off,
+        Math.round(dx),
+        Math.round(dy),
+        Math.round(dw),
+        Math.round(dh)
+      );
+    }
 
     const out = await canvasToBlob(canvas, type);
-    if (out) trigger(out, filename);
+    if (out) trigger(out, buildExportFilename(filename, fileExtension(type)));
   }
 }
 
-/**
- * SVG → PNG/JPG
- * 1) foreignObject → <text> 치환(+ 라벨 배경을 캔버스 배경과 선합성)
- * 2) viewBox/size 보정
- * 3) 폰트 로딩 대기(document.fonts)
- * 4) 네이티브 렌더(SVG→Image→drawImage), 실패 시 canvg 폴백
- */
+/** Export a raster image using the original diagram aspect ratio. */
 export async function downloadRasterFromSVG(
   svg: string,
   type: "image/png" | "image/jpeg",
@@ -118,60 +114,55 @@ export async function downloadRasterFromSVG(
   scale = 2,
   bg = "#ffffff"
 ) {
-  // A) foreignObject → <text> (정중앙 배치 + 계산된 스타일 인라인) + 선합성
+  const effectiveScale = normalizeScale(scale, 2);
   const textified = foreignObjectToCenteredText(svg, {
     canvasBg: bg,
     precompose: true,
   });
-
-  // B) viewBox/size 보정
   const normalized = normalizeSvgLight(textified);
 
-  // C) 출력 크기
   const size = parseSvgSize(normalized);
-  const w = Math.max(1, Math.floor(size.width * scale));
-  const h = Math.max(1, Math.floor(size.height * scale));
+  const w = Math.max(1, Math.floor(size.width * effectiveScale));
+  const h = Math.max(1, Math.floor(size.height * effectiveScale));
 
-  // D) 폰트 로딩 대기
   await waitFontsForSvg(normalized);
 
-  // E) 네이티브 렌더 경로
   try {
     const blob = new Blob([normalized], {
       type: "image/svg+xml;charset=utf-8",
     });
     const url = URL.createObjectURL(blob);
 
-    const { canvas, ctx } = makeCanvas(w, h);
-    // 배경
-    ctx.fillStyle = bg;
-    ctx.fillRect(0, 0, w, h);
+    try {
+      const { canvas, ctx } = makeCanvas(w, h);
+      ctx.fillStyle = bg;
+      ctx.fillRect(0, 0, w, h);
 
-    const img = await loadImage(url);
+      const img = await loadImage(url);
+      const vb = getViewBox(normalized) ?? {
+        x: 0,
+        y: 0,
+        w: size.width,
+        h: size.height,
+      };
+      const { dx, dy, dw, dh } = fitContain(vb.w, vb.h, w, h);
+      if (dw > 0 && dh > 0) {
+        ctx.drawImage(
+          img,
+          Math.round(dx),
+          Math.round(dy),
+          Math.round(dw),
+          Math.round(dh)
+        );
+      }
 
-    // viewBox 기준 비율 유지(xMidYMid meet)
-    const vb = getViewBox(normalized) ?? {
-      x: 0,
-      y: 0,
-      w: size.width,
-      h: size.height,
-    };
-    const { dx, dy, dw, dh } = fitContain(vb.w, vb.h, w, h);
-
-    // 픽셀 스냅(미세 블러/중앙 오차 방지)
-    const sDX = Math.round(dx);
-    const sDY = Math.round(dy);
-    const sDW = Math.round(dw);
-    const sDH = Math.round(dh);
-
-    ctx.drawImage(img, sDX, sDY, sDW, sDH);
-    queueMicrotask(() => URL.revokeObjectURL(url));
-
-    const out = await canvasToBlob(canvas, type);
-    if (out) trigger(out, filename);
-    return;
+      const out = await canvasToBlob(canvas, type);
+      if (out) trigger(out, buildExportFilename(filename, fileExtension(type)));
+      return;
+    } finally {
+      URL.revokeObjectURL(url);
+    }
   } catch {
-    // F) 폴백: canvg
     const { canvas, ctx } = makeCanvas(w, h);
     ctx.fillStyle = bg;
     ctx.fillRect(0, 0, w, h);
@@ -180,19 +171,15 @@ export async function downloadRasterFromSVG(
       ignoreDimensions: true,
       ignoreClear: true,
     });
-    // 일부 버전에서 resize 제공
-    if (typeof (v as any).resize === "function")
+    if (typeof (v as any).resize === "function") {
       (v as any).resize(w, h, "xMidYMid meet");
+    }
     await v.render();
 
     const out = await canvasToBlob(canvas, type);
-    if (out) trigger(out, filename);
+    if (out) trigger(out, buildExportFilename(filename, fileExtension(type)));
   }
 }
-
-/* ──────────────────────────
- * utils
- * ────────────────────────── */
 
 function trigger(blob: Blob, filename: string) {
   const a = document.createElement("a");
@@ -200,6 +187,38 @@ function trigger(blob: Blob, filename: string) {
   a.download = filename;
   a.click();
   URL.revokeObjectURL(a.href);
+}
+
+function buildExportFilename(input: string, extension: string) {
+  const base = stripKnownExtension(sanitizeFilename(input)).replace(/[. ]+$/g, "");
+  const ext = extension.replace(/^\./, "").toLowerCase();
+  return `${base || "diagram"}.${ext}`;
+}
+
+function sanitizeFilename(input: string) {
+  const fallback = "diagram";
+  const cleaned = input
+    .trim()
+    .replace(/[<>:"/\\|?*\u0000-\u001F]/g, "_")
+    .replace(/\s+/g, " ")
+    .replace(/[. ]+$/g, "");
+  return cleaned || fallback;
+}
+
+function stripKnownExtension(input: string) {
+  return input.replace(/\.(svg|png|jpe?g)$/i, "");
+}
+
+function fileExtension(type: "image/png" | "image/jpeg") {
+  return type === "image/png" ? "png" : "jpg";
+}
+
+function normalizeScale(value: number | undefined, fallback: number) {
+  return Number.isFinite(value) ? Math.max(0.1, value ?? fallback) : fallback;
+}
+
+function normalizeAspect(value: number, fallback: number) {
+  return Number.isFinite(value) ? Math.max(0.1, value) : fallback;
 }
 
 function makeCanvas(w: number, h: number) {
@@ -212,7 +231,6 @@ function makeCanvas(w: number, h: number) {
     throw new Error("2D canvas context is not supported in this environment.");
   }
   ctx.imageSmoothingEnabled = true;
-  // 타입 정의에 없어서 any 캐스팅
   (ctx as any).imageSmoothingQuality = "high";
   return { canvas, ctx };
 }
@@ -235,8 +253,10 @@ function canvasToBlob(
   );
 }
 
-/** viewBox 비율 유지(xMidYMid meet) */
 function fitContain(srcW: number, srcH: number, dstW: number, dstH: number) {
+  if (srcW <= 0 || srcH <= 0 || dstW <= 0 || dstH <= 0) {
+    return { dx: 0, dy: 0, dw: 0, dh: 0 };
+  }
   const s = Math.min(dstW / srcW, dstH / srcH);
   const dw = srcW * s;
   const dh = srcH * s;
@@ -249,11 +269,18 @@ function parseSvgSize(svg: string): { width: number; height: number } {
   const vb = svg.match(/viewBox\s*=\s*"([\d.\s-]+)"/i);
   if (vb?.[1]) {
     const p = vb[1].trim().split(/\s+/).map(Number);
-    if (p.length === 4) return { width: p[2], height: p[3] };
+    if (p.length === 4 && p[2] > 0 && p[3] > 0) {
+      return { width: p[2], height: p[3] };
+    }
   }
   const w = svg.match(/width\s*=\s*"([\d.]+)(px)?"/i)?.[1];
   const h = svg.match(/height\s*=\s*"([\d.]+)(px)?"/i)?.[1];
-  return { width: w ? Number(w) : 800, height: h ? Number(h) : 600 };
+  const width = w ? Number(w) : 800;
+  const height = h ? Number(h) : 600;
+  return {
+    width: Number.isFinite(width) && width > 0 ? width : 800,
+    height: Number.isFinite(height) && height > 0 ? height : 600,
+  };
 }
 
 function getViewBox(
@@ -262,6 +289,7 @@ function getViewBox(
   const m = svg.match(/viewBox\s*=\s*"([\d.\s-]+)"/i);
   if (!m?.[1]) return null;
   const [x, y, w, h] = m[1].trim().split(/\s+/).map(Number);
+  if (![x, y, w, h].every((v) => Number.isFinite(v))) return null;
   return { x, y, w, h };
 }
 
@@ -270,7 +298,6 @@ function normalizeSvgLight(svgString: string): string {
   const doc = parser.parseFromString(svgString, "image/svg+xml");
   const svg = doc.documentElement;
 
-  // viewBox 없고 width/height만 있는 경우 보정
   const hasViewBox = svg.hasAttribute("viewBox");
   const widthAttr = svg.getAttribute("width");
   const heightAttr = svg.getAttribute("height");
@@ -281,7 +308,6 @@ function normalizeSvgLight(svgString: string): string {
   }
   if (!svg.getAttribute("width")) svg.setAttribute("width", "800");
   if (!svg.getAttribute("height")) svg.setAttribute("height", "600");
-
   if (!svg.getAttribute("text-rendering")) {
     svg.setAttribute("text-rendering", "optimizeLegibility");
   }
@@ -289,13 +315,9 @@ function normalizeSvgLight(svgString: string): string {
   return new XMLSerializer().serializeToString(svg);
 }
 
-/* ──────────────────────────
- * 폰트 로딩 대기 (lint 안정형)
- * ────────────────────────── */
-
 async function waitFontsForSvg(svgString: string) {
   const families = collectFontFamilies(svgString);
-  const promises: Promise<any>[] = [];
+  const promises: Promise<unknown>[] = [];
   if ("fonts" in document) {
     for (const ff of families) {
       promises.push((document as any).fonts.load(`16px ${ff}`));
@@ -310,7 +332,6 @@ async function waitFontsForSvg(svgString: string) {
 function collectFontFamilies(svg: string): Set<string> {
   const set = new Set<string>();
 
-  // style 속성/태그 내 font-family
   const re = /font-family\s*:\s*([^;"]+)/gi;
   let m: RegExpExecArray | null;
   for (;;) {
@@ -320,12 +341,9 @@ function collectFontFamilies(svg: string): Set<string> {
       .split(",")
       .map((s) => s.trim().replace(/^['"]|['"]$/g, ""))
       .filter(Boolean)
-      .forEach((name) => {
-        set.add(name);
-      });
+      .forEach((name) => set.add(name));
   }
 
-  // 요소 속성 font-family=""
   const reAttr = /font-family\s*=\s*"([^"]+)"/gi;
   for (;;) {
     m = reAttr.exec(svg);
@@ -334,9 +352,7 @@ function collectFontFamilies(svg: string): Set<string> {
       .split(",")
       .map((s) => s.trim().replace(/^['"]|['"]$/g, ""))
       .filter(Boolean)
-      .forEach((name) => {
-        set.add(name);
-      });
+      .forEach((name) => set.add(name));
   }
 
   if (set.size === 0) {
@@ -347,13 +363,6 @@ function collectFontFamilies(svg: string): Set<string> {
   return set;
 }
 
-/* ──────────────────────────
- * 핵심: foreignObject → <text> (정중앙 배치 + 계산된 스타일 인라인)
- *  - 배경은 캔버스 배경과 미리 합성(pre-compose)하여 불투명 색으로 치환
- *  - 가로/세로 중앙: text-anchor="middle", dominant-baseline="middle"
- *  - 멀티라인: tspan으로 중앙 기준 균등 배치
- *  - 위치는 부모 transform 유지(원래 도형 자리)
- * ────────────────────────── */
 function foreignObjectToCenteredText(
   svgString: string,
   opts?: { canvasBg?: string; precompose?: boolean }
@@ -362,7 +371,6 @@ function foreignObjectToCenteredText(
   const srcDoc = parser.parseFromString(svgString, "image/svg+xml");
   const srcSvg = srcDoc.documentElement;
 
-  // 계산된 스타일용 숨김 DOM
   const host = document.createElement("div");
   host.style.cssText =
     "position:fixed;left:-99999px;top:-99999px;width:0;height:0;overflow:hidden;";
@@ -371,107 +379,93 @@ function foreignObjectToCenteredText(
   host.appendChild(shadowSvg);
   document.body.appendChild(host);
 
-  const foList = Array.from(srcSvg.querySelectorAll("foreignObject"));
-  const foListShadow = Array.from(shadowSvg.querySelectorAll("foreignObject"));
+  try {
+    const foList = Array.from(srcSvg.querySelectorAll("foreignObject"));
+    const foListShadow = Array.from(shadowSvg.querySelectorAll("foreignObject"));
 
-  const canvasBgHex = cssColorToHex(opts?.canvasBg ?? "#ffffff");
-  const doPrecompose = !!opts?.precompose;
+    const canvasBgHex = cssColorToHex(opts?.canvasBg ?? "#ffffff");
+    const doPrecompose = !!opts?.precompose;
 
-  foList.forEach((fo, i) => {
-    const foShadow = foListShadow[i];
-    if (!foShadow) return;
+    foList.forEach((fo, i) => {
+      const foShadow = foListShadow[i];
+      if (!foShadow) return;
 
-    const textContent = (foShadow.textContent || "").trim();
-    if (!textContent) {
-      fo.remove();
-      return;
-    }
+      const textContent = (foShadow.textContent || "").trim();
+      if (!textContent) {
+        fo.remove();
+        return;
+      }
 
-    const inner = foShadow.querySelector("*") as Element | null;
-    const cs = inner ? window.getComputedStyle(inner) : null;
+      const inner = foShadow.querySelector("*") as Element | null;
+      const cs = inner ? window.getComputedStyle(inner) : null;
 
-    const color = cs?.color || "rgb(0,0,0)";
-    const fontFamily =
-      cs?.fontFamily ||
-      "system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif";
-    const fontSize = cs?.fontSize || "14px";
-    const fontWeight = cs?.fontWeight || "400";
+      const color = cs?.color || "rgb(0,0,0)";
+      const fontFamily =
+        cs?.fontFamily ||
+        "system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif";
+      const fontSize = cs?.fontSize || "14px";
+      const fontWeight = cs?.fontWeight || "400";
 
-    // 배경/패딩/라운드/테두리
-    const bgColorCss = cs?.backgroundColor || "rgba(0,0,0,0)";
-    const { hex: bgHex, a: bgAlpha } = cssColorToHexA(bgColorCss);
+      const bgColorCss = cs?.backgroundColor || "rgba(0,0,0,0)";
+      const { hex: bgHex, a: bgAlpha } = cssColorToHexA(bgColorCss);
+      const padT = pxNum(cs?.paddingTop, 0);
+      const padR = pxNum(cs?.paddingRight, 0);
+      const padB = pxNum(cs?.paddingBottom, 0);
+      const padL = pxNum(cs?.paddingLeft, 0);
+      const radius = pxNum(cs?.borderTopLeftRadius, 0);
+      const borderW = pxNum(cs?.borderTopWidth, 0);
+      const borderColorCss = cs?.borderTopColor || "rgba(0,0,0,0)";
+      const { hex: borderHex, a: borderAlpha } = cssColorToHexA(borderColorCss);
 
-    const padT = pxNum(cs?.paddingTop, 0);
-    const padR = pxNum(cs?.paddingRight, 0);
-    const padB = pxNum(cs?.paddingBottom, 0);
-    const padL = pxNum(cs?.paddingLeft, 0);
+      const width = Number(fo.getAttribute("width") || 0);
+      const height = Number(fo.getAttribute("height") || 0);
+      const g = srcDoc.createElementNS("http://www.w3.org/2000/svg", "g");
+      const tf = fo.getAttribute("transform");
+      if (tf) g.setAttribute("transform", tf);
 
-    const radius = pxNum(cs?.borderTopLeftRadius, 0);
+      const textNode = srcDoc.createElementNS(
+        "http://www.w3.org/2000/svg",
+        "text"
+      );
+      const fsNum = parseFloat(fontSize) || 14;
+      const lineHeight = fsNum * 1.2;
+      const cx = width / 2;
+      const cy = height / 2;
 
-    const borderW = pxNum(cs?.borderTopWidth, 0);
-    const borderColorCss = cs?.borderTopColor || "rgba(0,0,0,0)";
-    const { hex: borderHex, a: borderAlpha } = cssColorToHexA(borderColorCss);
+      textNode.setAttribute("x", String(cx));
+      textNode.setAttribute("y", String(cy));
+      textNode.setAttribute("text-anchor", "middle");
+      textNode.setAttribute("dominant-baseline", "middle");
+      textNode.setAttribute("fill", cssColorToHex(color));
+      textNode.setAttribute("font-family", fontFamily);
+      textNode.setAttribute("font-size", fontSize);
+      textNode.setAttribute("font-weight", fontWeight);
+      textNode.setAttribute("opacity", "1");
 
-    const width = Number(fo.getAttribute("width") || 0);
-    const height = Number(fo.getAttribute("height") || 0);
+      const lines = textContent.split(/\r?\n/).map((s) => s.trim());
+      if (lines.length === 1) {
+        textNode.textContent = lines[0];
+      } else {
+        const total = (lines.length - 1) * lineHeight;
+        const yStart = cy - total / 2;
+        lines.forEach((line, idx) => {
+          const tspan = srcDoc.createElementNS(
+            "http://www.w3.org/2000/svg",
+            "tspan"
+          );
+          tspan.setAttribute("x", String(cx));
+          tspan.setAttribute("y", String(yStart + idx * lineHeight));
+          tspan.textContent = line;
+          textNode.appendChild(tspan);
+        });
+      }
 
-    // 부모 transform 계승
-    const g = srcDoc.createElementNS("http://www.w3.org/2000/svg", "g");
-    const tf = fo.getAttribute("transform");
-    if (tf) g.setAttribute("transform", tf);
-
-    const textNode = srcDoc.createElementNS(
-      "http://www.w3.org/2000/svg",
-      "text"
-    );
-
-    const fsNum = parseFloat(fontSize) || 14;
-    const lineHeight = fsNum * 1.2;
-
-    // 기하학적 중앙 좌표
-    const cx = (width || 0) / 2;
-    const cy = (height || 0) / 2;
-
-    textNode.setAttribute("x", String(cx));
-    textNode.setAttribute("y", String(cy));
-    textNode.setAttribute("text-anchor", "middle");
-    textNode.setAttribute("dominant-baseline", "middle");
-
-    // 스타일 인라인
-    textNode.setAttribute("fill", cssColorToHex(color));
-    textNode.setAttribute("font-family", fontFamily);
-    textNode.setAttribute("font-size", fontSize);
-    textNode.setAttribute("font-weight", fontWeight);
-    textNode.setAttribute("opacity", "1");
-
-    // 멀티라인 처리: 중앙 기준 위/아래 균등 분포
-    const lines = textContent.split(/\r?\n/).map((s) => s.trim());
-    if (lines.length === 1) {
-      textNode.textContent = lines[0];
-    } else {
-      const total = (lines.length - 1) * lineHeight;
-      const yStart = cy - total / 2;
-      lines.forEach((line, idx) => {
-        const tspan = srcDoc.createElementNS(
-          "http://www.w3.org/2000/svg",
-          "tspan"
-        );
-        tspan.setAttribute("x", String(cx));
-        tspan.setAttribute("y", String(yStart + idx * lineHeight));
-        tspan.textContent = line;
-        textNode.appendChild(tspan);
-      });
-    }
-
-    // 텍스트 블록 측정 후 배경 rect 삽입
-    {
       const fontForMeasure = `${fontWeight} ${fontSize} ${fontFamily}`;
       const { width: tw, height: th } = measureTextBlock(
         lines.length ? lines : [textNode.textContent || ""],
         fontForMeasure,
         lineHeight
       );
-
       const bw = tw + padL + padR;
       const bh = th + padT + padB;
 
@@ -489,15 +483,13 @@ function foreignObjectToCenteredText(
           rect.setAttribute("ry", String(radius));
         }
 
-        // ▼ 최소 가시성 하한 + 선합성
         const minAlpha = 1;
         const effAlpha = Math.max(bgAlpha, minAlpha);
-
         let finalFill = bgHex;
         let finalFillOpacity = 1;
 
         if (doPrecompose && effAlpha < 1) {
-          finalFill = blendOver(bgHex, canvasBgHex, effAlpha); // 불투명 색으로 치환
+          finalFill = blendOver(bgHex, canvasBgHex, effAlpha);
           finalFillOpacity = 1;
         } else {
           finalFillOpacity = effAlpha;
@@ -505,14 +497,15 @@ function foreignObjectToCenteredText(
 
         rect.setAttribute("fill", finalFill);
         rect.setAttribute("opacity", "1");
-        if (finalFillOpacity < 1)
+        if (finalFillOpacity < 1) {
           rect.setAttribute("fill-opacity", String(finalFillOpacity));
+        }
 
-        // 대비 강화용 테두리(아주 옅게)
         if (borderW > 0 && borderAlpha > 0) {
           rect.setAttribute("stroke", borderHex);
-          if (borderAlpha < 1)
+          if (borderAlpha < 1) {
             rect.setAttribute("stroke-opacity", String(borderAlpha));
+          }
           rect.setAttribute("stroke-width", String(borderW));
         } else {
           rect.setAttribute("stroke", "#000000");
@@ -520,20 +513,19 @@ function foreignObjectToCenteredText(
           rect.setAttribute("stroke-width", "1");
         }
 
-        // z-order: 배경 → 텍스트
         g.appendChild(rect);
       }
-    }
 
-    g.appendChild(textNode);
-    fo.replaceWith(g);
-  });
+      g.appendChild(textNode);
+      fo.replaceWith(g);
+    });
 
-  host.remove();
-  return new XMLSerializer().serializeToString(srcSvg);
+    return new XMLSerializer().serializeToString(srcSvg);
+  } finally {
+    host.remove();
+  }
 }
 
-/* 색상 문자열 → hex6 */
 function cssColorToHex(input: string): string {
   if (/^#([0-9a-f]{3}|[0-9a-f]{6})$/i.test(input)) return input;
   const m = input.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/i);
@@ -551,28 +543,26 @@ function cssColorToHex(input: string): string {
   return cssColorToHex(cs || "#000000");
 }
 
-/** px 문자열 → number (기본값 fallback) */
 function pxNum(v?: string | null, fallback = 0) {
   if (!v) return fallback;
   const n = parseFloat(v);
   return Number.isFinite(n) ? n : fallback;
 }
 
-/** CSS color → { hex, a }  (rgba 처리: fill + fill-opacity 분리용) */
 function cssColorToHexA(input: string): { hex: string; a: number } {
   if (/^#([0-9a-f]{3}|[0-9a-f]{6})$/i.test(input)) return { hex: input, a: 1 };
 
   const tmp = document.createElement("div");
   tmp.style.color = input;
   document.body.appendChild(tmp);
-  const color = getComputedStyle(tmp).color; // rgb(a)
+  const color = getComputedStyle(tmp).color;
   document.body.removeChild(tmp);
 
   const m = color.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*([\d.]+))?\)/i);
   if (!m) return { hex: "#000000", a: 1 };
-  const r = Number(m[1]),
-    g = Number(m[2]),
-    b = Number(m[3]);
+  const r = Number(m[1]);
+  const g = Number(m[2]);
+  const b = Number(m[3]);
   const a = m[4] !== undefined ? Math.max(0, Math.min(1, Number(m[4]))) : 1;
   const hex = `#${r.toString(16).padStart(2, "0")}${g
     .toString(16)
@@ -580,7 +570,6 @@ function cssColorToHexA(input: string): { hex: string; a: number } {
   return { hex, a };
 }
 
-/** 오프스크린 Canvas로 멀티라인 텍스트 블록 측정 */
 function measureTextBlock(lines: string[], font: string, lineHeight: number) {
   const canvas = document.createElement("canvas");
   const ctx = canvas.getContext("2d");
@@ -597,7 +586,6 @@ function measureTextBlock(lines: string[], font: string, lineHeight: number) {
   return { width: Math.ceil(maxW), height: Math.ceil(height) };
 }
 
-/* ──────────────── 색상 합성 헬퍼 ──────────────── */
 function hexToRgb(hex: string) {
   const s = hex.replace("#", "");
   const arr =
@@ -610,6 +598,7 @@ function hexToRgb(hex: string) {
         ];
   return { r: arr[0], g: arr[1], b: arr[2] };
 }
+
 function rgbToHex(r: number, g: number, b: number) {
   const h = (x: number) =>
     Math.max(0, Math.min(255, Math.round(x)))
@@ -617,10 +606,10 @@ function rgbToHex(r: number, g: number, b: number) {
       .padStart(2, "0");
   return `#${h(r)}${h(g)}${h(b)}`;
 }
-/** fg(알파) 를 bg 위에 합성한 불투명 색 */
+
 function blendOver(fgHex: string, bgHex: string, a: number) {
-  const fg = hexToRgb(fgHex),
-    bg = hexToRgb(bgHex);
+  const fg = hexToRgb(fgHex);
+  const bg = hexToRgb(bgHex);
   const r = fg.r * a + bg.r * (1 - a);
   const g = fg.g * a + bg.g * (1 - a);
   const b = fg.b * a + bg.b * (1 - a);


### PR DESCRIPTION
## 변경 요약
내보내기 경로에서 파일명 정리, 포맷별 확장자 처리, 비활성화 상태, aspect 옵션 적용을 안정화했습니다.
특히 SVG/PNG/JPG export 시 사용자 입력 파일명이 어색하거나 비어 있어도 예측 가능한 결과가 나오도록 보강했습니다.

## 직접 테스트 가능 여부
가능

## 확인한 사항
| 항목 | 상태 |
| --- | --- |
| `git diff --check` | 통과 |
| 개발 환경 수동 확인 시나리오 | 아래 정리 |

## 테스트 시나리오
1. 빈 다이어그램 상태
코드를 비우거나 export가 불가능한 상태를 만듭니다.
Export 버튼과 포맷 선택 상태를 확인합니다.
기대 결과:
- Export 관련 버튼이 비활성화되거나 실행되지 않습니다.
- 잘못된 파일이 내려받아지지 않습니다.

2. SVG 선택 시 aspect preset 비활성화 확인
`Format`을 `SVG`로 선택합니다.
`Aspect` 옵션 상태를 확인합니다.
기대 결과:
- SVG에서는 preset aspect가 비활성화되거나 영향이 없습니다.
- SVG는 원본 viewBox 기준으로 자연스럽게 저장됩니다.

3. 확장자 중복 방지
파일명을 `diagram.svg`처럼 입력한 뒤 `PNG`로 내보냅니다.
기대 결과:
- 결과 파일명이 `diagram.png`처럼 정리됩니다.
- `diagram.svg.png`처럼 확장자가 중복되지 않습니다.

4. 파일명 정리 확인
파일명을 `demo:diagram`처럼 운영체제에서 문제가 될 수 있는 형태로 입력합니다.
그 다음 PNG 또는 JPG로 내보냅니다.
기대 결과:
- 저장 가능한 안전한 파일명으로 정리됩니다.
- 브라우저 다운로드가 실패하지 않습니다.

5. 16:9 비율 export
`Aspect`를 `16:9`로 선택한 뒤 PNG export를 실행합니다.
기대 결과:
- 결과 이미지가 지정한 비율 기준으로 생성됩니다.
- 배경색과 다이어그램 배치가 크게 어긋나지 않습니다.

6. original 비율 export
`Aspect`를 `original`로 두고 PNG와 JPG를 각각 내보냅니다.
기대 결과:
- 원본 SVG 크기 기준으로 내보내기가 동작합니다.
- 포맷만 바뀌고 배치가 예상과 크게 달라지지 않습니다.

## 참고
이 PR은 export 경로 안정화가 목적이며, 전후 성능 비교가 핵심인 변경은 아닙니다.