### PR TITLE
공유 링크 흐름 안정화

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+
 import { useEffect, useMemo, useState } from "react";
 import EditorSwitcher from "@/components/EditorSwitcher";
 import ExportButtons from "@/components/ExportButtons";
@@ -6,7 +7,23 @@ import MermaidPreview from "@/components/MermaidPreview";
 import TopBar from "@/components/TopBar";
 import { DEFAULTS, SAMPLE, THEMES, type Theme } from "@/libs/presets";
 import { decodeShareState } from "@/libs/share";
-import type { Mode } from "@/types/types";
+import type { ExportAspectOption, ExportFormat, Mode } from "@/types/types";
+
+type ShareState = {
+  bg?: string;
+  code?: string;
+  editorMode?: Mode;
+  exportAspect?: ExportAspectOption;
+  exportFilename?: string;
+  exportFormat?: ExportFormat;
+  exportScale?: number;
+  scale?: number;
+  theme?: Theme;
+};
+
+const DEFAULT_EXPORT_FORMAT: ExportFormat = "png";
+const DEFAULT_EXPORT_ASPECT: ExportAspectOption = "original";
+const DEFAULT_EXPORT_FILENAME = "diagram";
 
 export default function Page() {
   const [code, setCode] = useState(SAMPLE);
@@ -14,36 +31,64 @@ export default function Page() {
   const [bg, setBg] = useState(DEFAULTS.bg);
   const [scale, setScale] = useState(DEFAULTS.scale);
   const [exportScale, setExportScale] = useState(DEFAULTS.exportScale);
+  const [exportFormat, setExportFormat] = useState<ExportFormat>(
+    DEFAULT_EXPORT_FORMAT,
+  );
+  const [exportAspect, setExportAspect] = useState<ExportAspectOption>(
+    DEFAULT_EXPORT_ASPECT,
+  );
+  const [exportFilename, setExportFilename] = useState(DEFAULT_EXPORT_FILENAME);
   const [editorMode, setEditorMode] = useState<Mode>("codemirror");
   const [svg, setSvg] = useState("");
 
   useEffect(() => {
     const s = new URLSearchParams(location.search).get("s");
-    if (s) {
-      const restored = decodeShareState<any>(s);
-      if (restored) {
-        setCode(restored.code ?? SAMPLE);
-        setTheme(restored.theme ?? DEFAULTS.theme);
-        setBg(restored.bg ?? DEFAULTS.bg);
-        setScale(restored.scale ?? DEFAULTS.scale);
-        setExportScale(restored.exportScale ?? DEFAULTS.exportScale);
-        setEditorMode(restored.editorMode ?? "codemirror");
-      }
-    }
+    if (!s) return;
+
+    const restored = decodeShareState<ShareState>(s);
+    if (!restored) return;
+
+    setCode(restored.code ?? SAMPLE);
+    setTheme(restored.theme ?? DEFAULTS.theme);
+    setBg(restored.bg ?? DEFAULTS.bg);
+    setScale(restored.scale ?? DEFAULTS.scale);
+    setExportScale(restored.exportScale ?? DEFAULTS.exportScale);
+    setExportFormat(restored.exportFormat ?? DEFAULT_EXPORT_FORMAT);
+    setExportAspect(restored.exportAspect ?? DEFAULT_EXPORT_ASPECT);
+    setExportFilename(restored.exportFilename ?? DEFAULT_EXPORT_FILENAME);
+    setEditorMode(restored.editorMode ?? "codemirror");
   }, []);
 
   const shareState = useMemo(
-    () => ({ code, theme, bg, scale, exportScale, editorMode }),
-    [code, theme, bg, scale, exportScale, editorMode]
+    () => ({
+      code,
+      theme,
+      bg,
+      scale,
+      exportScale,
+      exportFormat,
+      exportAspect,
+      exportFilename,
+      editorMode,
+    }),
+    [
+      bg,
+      code,
+      editorMode,
+      exportAspect,
+      exportFilename,
+      exportFormat,
+      exportScale,
+      scale,
+      theme,
+    ],
   );
 
   return (
     <main className="mx-auto max-w-[1400px] p-4">
       <TopBar state={shareState} />
 
-      {/* 레이아웃: 좌측 에디터(고정폭), 우측 프리뷰(가변폭) */}
       <div className="mt-4 grid gap-4 lg:grid-cols-[minmax(360px,480px)_1fr]">
-        {/* Editor Panel */}
         <aside className="h-fit sticky top-4 self-start rounded-2xl border border-slate-200/80 bg-white/70 backdrop-blur p-3 lg:p-4 shadow-sm">
           <div className="mb-3 flex items-center justify-between">
             <span className="text-sm font-semibold text-slate-700">Editor</span>
@@ -58,13 +103,9 @@ export default function Page() {
           />
         </aside>
 
-        {/* Preview + Toolbar Panel */}
         <section className="rounded-2xl border border-slate-200/80 bg-white/60 backdrop-blur shadow-sm flex flex-col">
-          {/* Toolbar — 중앙 정렬 + 높이 통일 */}
           <div className="flex flex-wrap items-center gap-2 lg:gap-3 border-b border-slate-200/70 p-3 lg:p-4 h-22">
-            {/* Theme + Background (살짝 위로) */}
             <div className="flex flex-wrap items-center gap-3 self-start mt-1">
-              {/* Theme */}
               <div className="inline-flex items-center gap-2">
                 <label
                   htmlFor="themeSelect"
@@ -86,7 +127,6 @@ export default function Page() {
                 </select>
               </div>
 
-              {/* Background */}
               <div className="inline-flex items-center gap-2">
                 <label
                   htmlFor="bgPicker"
@@ -104,18 +144,22 @@ export default function Page() {
               </div>
             </div>
 
-            {/* Export Controls (기존 위치 유지, 중앙선 정렬) */}
             <div className="ml-auto self-center">
               <ExportButtons
+                aspect={exportAspect}
                 svg={svg}
                 bg={bg}
                 exportScale={exportScale}
+                filename={exportFilename}
+                format={exportFormat}
+                onAspectChange={setExportAspect}
+                onFilenameChange={setExportFilename}
+                onFormatChange={setExportFormat}
                 className="bg-white/80"
               />
             </div>
           </div>
 
-          {/* Preview 영역 */}
           <div className="relative flex-1 p-3 lg:p-4">
             <div className="rounded-xl border border-slate-200 bg-white shadow-sm">
               <div className="p-2">

--- a/components/ExportButtons.tsx
+++ b/components/ExportButtons.tsx
@@ -1,96 +1,116 @@
 "use client";
-import { useMemo, useState } from "react";
+
+import { useMemo } from "react";
 import {
   downloadRasterForAspect,
   downloadRasterFromSVG,
   downloadSVG,
 } from "@/libs/svgExport";
-import { ASPECT_MAP, type AspectPreset } from "@/types/types";
-
-type ExportFormat = "svg" | "png" | "jpg";
-type AspectOption = "original" | AspectPreset;
+import {
+  ASPECT_MAP,
+  type ExportAspectOption,
+  type ExportFormat,
+} from "@/types/types";
 
 export default function ExportButtons({
-  svg,
+  aspect,
   bg,
-  exportScale,
   className = "",
+  exportScale,
+  filename,
+  format,
+  onAspectChange,
+  onFilenameChange,
+  onFormatChange,
+  svg,
 }: {
-  svg: string;
+  aspect: ExportAspectOption;
   bg: string;
-  exportScale: number;
   className?: string;
+  exportScale: number;
+  filename: string;
+  format: ExportFormat;
+  onAspectChange: (value: ExportAspectOption) => void;
+  onFilenameChange: (value: string) => void;
+  onFormatChange: (value: ExportFormat) => void;
+  svg: string;
 }) {
-  const [format, setFormat] = useState<ExportFormat>("png");
-  const [aspect, setAspect] = useState<AspectOption>("original");
-  const [filename, setFilename] = useState("diagram");
+  const hasDiagram = svg.trim().length > 0;
+  const isAspectDisabled = format === "svg" || !hasDiagram;
 
   const hint = useMemo(() => {
-    if (format === "svg")
-      return "SVG는 벡터 포맷이라 비율/배경 개념이 없습니다.";
-    if (aspect === "original") return "원본 비율·배율로 내보냅니다.";
-    return `프리셋 비율(${aspect})로 캔버스를 맞춰 내보냅니다.`;
-  }, [format, aspect]);
+    if (!hasDiagram) {
+      return "Render a valid Mermaid diagram to enable export.";
+    }
+    if (format === "svg") {
+      return "SVG export stays vector-based and ignores aspect presets.";
+    }
+    if (aspect === "original") {
+      return "Exports at the diagram's original aspect ratio.";
+    }
+    return `Exports on a ${aspect} canvas and centers the diagram.`;
+  }, [aspect, format, hasDiagram]);
 
   const handleExport = () => {
-    if (!svg) return;
+    if (!hasDiagram) return;
 
     if (format === "svg") {
       downloadSVG(svg, `${filename}.svg`);
       return;
     }
+
     const mime = format === "png" ? "image/png" : "image/jpeg";
     const ext = format === "png" ? "png" : "jpg";
 
     if (aspect === "original") {
       downloadRasterFromSVG(svg, mime, `${filename}.${ext}`, exportScale, bg);
-    } else {
-      downloadRasterForAspect(svg, `${filename}.${ext}`, mime, {
-        aspect: ASPECT_MAP[aspect],
-        scale: exportScale,
-        background: bg,
-      });
+      return;
     }
-  };
 
-  const isAspectDisabled = format === "svg";
+    downloadRasterForAspect(svg, `${filename}.${ext}`, mime, {
+      aspect: ASPECT_MAP[aspect],
+      scale: exportScale,
+      background: bg,
+    });
+  };
 
   return (
     <section
       className={["min-w-0", className].join(" ")}
       aria-label="Export toolbar"
     >
-      {/* ── 툴바 (한 줄) ───────────────────────────────────────────── */}
       <div
         className={[
           "flex items-center gap-2 rounded-xl border border-slate-200/80 bg-white/70",
           "backdrop-blur px-2 py-1 shadow-sm whitespace-nowrap overflow-x-auto",
         ].join(" ")}
       >
-        {/* 파일명 */}
         <label htmlFor="filename" className="sr-only">
-          파일명
+          File name
         </label>
         <input
           id="filename"
           value={filename}
-          onChange={(e) => setFilename(e.target.value)}
+          onChange={(e) => onFilenameChange(e.target.value)}
           className="max-w-[160px] truncate rounded-lg border border-slate-200 px-2 h-8 text-sm outline-none focus:ring-2 focus:ring-slate-300"
           placeholder="diagram"
           spellCheck={false}
         />
 
-        <span className="text-slate-300 select-none">•</span>
+        <span className="text-slate-300 select-none">/</span>
 
-        {/* 포맷 */}
         <label htmlFor="format" className="sr-only">
-          포맷
+          Export format
         </label>
         <select
           id="format"
           value={format}
-          onChange={(e) => setFormat(e.target.value as ExportFormat)}
-          className="rounded-lg border border-slate-200 px-2 h-8 text-sm bg-white outline-none focus:ring-2 focus:ring-slate-300"
+          onChange={(e) => onFormatChange(e.target.value as ExportFormat)}
+          disabled={!hasDiagram}
+          className={[
+            "rounded-lg border border-slate-200 px-2 h-8 text-sm bg-white outline-none focus:ring-2 focus:ring-slate-300",
+            !hasDiagram ? "cursor-not-allowed opacity-60" : "",
+          ].join(" ")}
           aria-label="Export format"
         >
           <option value="png">PNG</option>
@@ -98,38 +118,42 @@ export default function ExportButtons({
           <option value="svg">SVG</option>
         </select>
 
-        {/* 비율 */}
         <label htmlFor="aspect" className="sr-only">
-          비율
+          Aspect ratio
         </label>
         <select
           id="aspect"
           value={isAspectDisabled ? "original" : aspect}
-          onChange={(e) => setAspect(e.target.value as AspectOption)}
+          onChange={(e) => onAspectChange(e.target.value as ExportAspectOption)}
           disabled={isAspectDisabled}
           className={[
             "rounded-lg border border-slate-200 px-2 h-8 text-sm bg-white outline-none focus:ring-2 focus:ring-slate-300",
-            isAspectDisabled ? "opacity-60 cursor-not-allowed" : "",
+            isAspectDisabled ? "cursor-not-allowed opacity-60" : "",
           ].join(" ")}
           aria-label="Aspect ratio preset"
         >
-          <option value="original">원본</option>
+          <option value="original">Original</option>
           <option value="3:2">3:2</option>
           <option value="4:3">4:3</option>
           <option value="16:9">16:9</option>
         </select>
 
-        {/* Export 버튼 */}
         <button
           type="button"
           onClick={handleExport}
-          className="ml-1 rounded-lg px-3 h-8 text-sm font-semibold bg-slate-900 text-white hover:bg-slate-800 active:scale-[0.99] focus:outline-none focus:ring-2 focus:ring-slate-300 transition shadow-sm"
+          disabled={!hasDiagram}
+          aria-disabled={!hasDiagram}
+          className={[
+            "ml-1 rounded-lg px-3 h-8 text-sm font-semibold text-white shadow-sm transition",
+            hasDiagram
+              ? "bg-slate-900 hover:bg-slate-800 active:scale-[0.99] focus:outline-none focus:ring-2 focus:ring-slate-300"
+              : "cursor-not-allowed bg-slate-400 opacity-70",
+          ].join(" ")}
         >
           Export
         </button>
       </div>
 
-      {/* ── 상시 노출 힌트 (한 줄, 말줄임) ─────────────────────────── */}
       <p
         className="mt-1 text-[11px] leading-tight text-slate-500 whitespace-nowrap overflow-hidden text-ellipsis"
         aria-live="polite"

--- a/components/TopBar.tsx
+++ b/components/TopBar.tsx
@@ -42,8 +42,12 @@ export default function TopBar({ state }: TopBarProps) {
 
   const copyViaClipboardApi = async (value: string) => {
     if (!navigator.clipboard?.writeText) return false;
-    await navigator.clipboard.writeText(value);
-    return true;
+    try {
+      await navigator.clipboard.writeText(value);
+      return true;
+    } catch {
+      return false;
+    }
   };
 
   const copyViaTextarea = (value: string) => {

--- a/components/TopBar.tsx
+++ b/components/TopBar.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
 import { BookOpenText, ExternalLink, Link2 } from "lucide-react";
 import Image from "next/image";
+import { useEffect, useRef, useState } from "react";
 import { buildShareUrl } from "@/libs/share";
 
 type TopBarProps = {
@@ -73,7 +73,7 @@ export default function TopBar({ state }: TopBarProps) {
   const onShare = async () => {
     if (isSharing) return;
 
-    const url = buildShareUrl(state, window.location.origin);
+    const url = buildShareUrl(state, window.location.href);
     if (!url) {
       showStatus({
         tone: "error",
@@ -96,7 +96,8 @@ export default function TopBar({ state }: TopBarProps) {
     } catch {
       showStatus({
         tone: "error",
-        message: "Could not copy automatically. The share link is ready to use.",
+        message:
+          "Could not copy automatically. The share link is ready to use.",
       });
     } finally {
       setIsSharing(false);

--- a/components/TopBar.tsx
+++ b/components/TopBar.tsx
@@ -1,19 +1,106 @@
 "use client";
 
+import { useEffect, useRef, useState } from "react";
 import { BookOpenText, ExternalLink, Link2 } from "lucide-react";
 import Image from "next/image";
-import { encodeShareState } from "@/libs/share";
+import { buildShareUrl } from "@/libs/share";
 
 type TopBarProps = {
   state: unknown;
 };
 
+type ShareStatus = {
+  tone: "success" | "error";
+  message: string;
+};
+
+const STATUS_CLEAR_MS = 2500;
+
 export default function TopBar({ state }: TopBarProps) {
-  const onShare = () => {
-    const b64 = encodeShareState(state);
-    const url = `${location.origin}?s=${encodeURIComponent(b64)}`;
-    navigator.clipboard.writeText(url);
-    alert("공유 링크가 복사되었습니다.");
+  const [isSharing, setIsSharing] = useState(false);
+  const [status, setStatus] = useState<ShareStatus | null>(null);
+  const statusTimerRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (statusTimerRef.current !== null) {
+        window.clearTimeout(statusTimerRef.current);
+      }
+    };
+  }, []);
+
+  const showStatus = (nextStatus: ShareStatus) => {
+    setStatus(nextStatus);
+    if (statusTimerRef.current !== null) {
+      window.clearTimeout(statusTimerRef.current);
+    }
+    statusTimerRef.current = window.setTimeout(() => {
+      setStatus(null);
+      statusTimerRef.current = null;
+    }, STATUS_CLEAR_MS);
+  };
+
+  const copyViaClipboardApi = async (value: string) => {
+    if (!navigator.clipboard?.writeText) return false;
+    await navigator.clipboard.writeText(value);
+    return true;
+  };
+
+  const copyViaTextarea = (value: string) => {
+    const textarea = document.createElement("textarea");
+    textarea.value = value;
+    textarea.readOnly = true;
+    textarea.setAttribute("aria-hidden", "true");
+    textarea.style.position = "fixed";
+    textarea.style.top = "0";
+    textarea.style.left = "-9999px";
+    textarea.style.opacity = "0";
+    document.body.appendChild(textarea);
+    textarea.select();
+    textarea.setSelectionRange(0, textarea.value.length);
+
+    let copied = false;
+    try {
+      copied = document.execCommand("copy");
+    } catch {
+      copied = false;
+    } finally {
+      document.body.removeChild(textarea);
+    }
+    return copied;
+  };
+
+  const onShare = async () => {
+    if (isSharing) return;
+
+    const url = buildShareUrl(state, window.location.origin);
+    if (!url) {
+      showStatus({
+        tone: "error",
+        message: "Unable to generate a share link from the current state.",
+      });
+      return;
+    }
+
+    setIsSharing(true);
+    try {
+      const copied = await copyViaClipboardApi(url);
+      if (!copied && !copyViaTextarea(url)) {
+        throw new Error("Unable to copy share link.");
+      }
+
+      showStatus({
+        tone: "success",
+        message: "Share link copied to clipboard.",
+      });
+    } catch {
+      showStatus({
+        tone: "error",
+        message: "Could not copy automatically. The share link is ready to use.",
+      });
+    } finally {
+      setIsSharing(false);
+    }
   };
 
   return (
@@ -27,7 +114,6 @@ export default function TopBar({ state }: TopBarProps) {
         dark:bg-slate-900/60 dark:border-slate-800 dark:text-slate-100
       "
     >
-      {/* 좌측: 로고 + 타이틀 */}
       <div className="flex items-center gap-2 font-extrabold tracking-tight text-slate-800 dark:text-slate-100">
         <Image
           src="/favicon.svg"
@@ -40,44 +126,60 @@ export default function TopBar({ state }: TopBarProps) {
         <span className="text-sm sm:text-base">Mermaid Sky Exporter</span>
       </div>
 
-      {/* 우측: 툴바 */}
-      <div className="flex items-center gap-2">
-        <button
-          type="button"
-          onClick={onShare}
-          className="
-            inline-flex items-center gap-1.5
-            rounded-xl px-3 py-2 text-sm font-semibold
-            text-white shadow-sm ring-1 ring-inset ring-slate-900/5
-            bg-indigo-600 hover:bg-indigo-500 active:translate-y-[1px]
-            focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400
-            dark:bg-indigo-500 dark:hover:bg-indigo-400
-            transition
-          "
-        >
-          <Link2 className="size-4" aria-hidden />
-          <span>Share Link</span>
-        </button>
+      <div className="flex flex-col items-end gap-1">
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={onShare}
+            disabled={isSharing}
+            aria-busy={isSharing}
+            className="
+              inline-flex items-center gap-1.5
+              rounded-xl px-3 py-2 text-sm font-semibold
+              text-white shadow-sm ring-1 ring-inset ring-slate-900/5
+              bg-indigo-600 hover:bg-indigo-500 active:translate-y-[1px]
+              focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400
+              disabled:cursor-not-allowed disabled:opacity-70
+              dark:bg-indigo-500 dark:hover:bg-indigo-400
+              transition
+            "
+          >
+            <Link2 className="size-4" aria-hidden />
+            <span>{isSharing ? "Sharing..." : "Share Link"}</span>
+          </button>
 
-        <a
-          href="https://mermaid.js.org/"
-          target="_blank"
-          rel="noreferrer"
-          className="
-            inline-flex items-center gap-1.5
-            rounded-xl px-3 py-2 text-sm font-semibold
-            border border-slate-200 bg-white/70 text-slate-700
-            hover:bg-slate-50 active:translate-y-[1px]
-            focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-300
-            dark:border-slate-700 dark:bg-slate-800/60 dark:text-slate-100
-            dark:hover:bg-slate-800
-            transition
-          "
+          <a
+            href="https://mermaid.js.org/"
+            target="_blank"
+            rel="noreferrer"
+            className="
+              inline-flex items-center gap-1.5
+              rounded-xl px-3 py-2 text-sm font-semibold
+              border border-slate-200 bg-white/70 text-slate-700
+              hover:bg-slate-50 active:translate-y-[1px]
+              focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-300
+              dark:border-slate-700 dark:bg-slate-800/60 dark:text-slate-100
+              dark:hover:bg-slate-800
+              transition
+            "
+          >
+            <BookOpenText className="size-4" aria-hidden />
+            <span className="whitespace-nowrap">Mermaid Docs</span>
+            <ExternalLink className="size-3.5 opacity-70" aria-hidden />
+          </a>
+        </div>
+
+        <p
+          role="status"
+          aria-live="polite"
+          aria-atomic="true"
+          className={[
+            "min-h-4 text-[11px] leading-tight",
+            status?.tone === "error" ? "text-rose-600" : "text-slate-500",
+          ].join(" ")}
         >
-          <BookOpenText className="size-4" aria-hidden />
-          <span className="whitespace-nowrap">Mermaid Docs</span>
-          <ExternalLink className="size-3.5 opacity-70" aria-hidden />
-        </a>
+          {status?.message ?? " "}
+        </p>
       </div>
     </div>
   );

--- a/libs/share.ts
+++ b/libs/share.ts
@@ -13,11 +13,19 @@ export function encodeShareState(state: unknown): string | null {
 
 export function buildShareUrl(
   state: unknown,
-  origin: string = typeof window !== "undefined" ? window.location.origin : ""
+  baseUrl: string = typeof window !== "undefined" ? window.location.href : "",
 ): string | null {
   const encoded = encodeShareState(state);
-  if (!encoded || !origin) return null;
-  return `${origin}?s=${encodeURIComponent(encoded)}`;
+  if (!encoded || !baseUrl) return null;
+
+  try {
+    const url = new URL(baseUrl);
+    url.searchParams.set("s", encoded);
+    url.hash = "";
+    return url.toString();
+  } catch {
+    return null;
+  }
 }
 
 export function decodeShareState<T = unknown>(s: string): T | null {

--- a/libs/share.ts
+++ b/libs/share.ts
@@ -3,11 +3,24 @@ import {
   decompressFromEncodedURIComponent,
 } from "lz-string";
 
-export function encodeShareState(state: unknown) {
-  return compressToEncodedURIComponent(JSON.stringify(state));
+export function encodeShareState(state: unknown): string | null {
+  try {
+    return compressToEncodedURIComponent(JSON.stringify(state));
+  } catch {
+    return null;
+  }
 }
 
-export function decodeShareState<T = any>(s: string): T | null {
+export function buildShareUrl(
+  state: unknown,
+  origin: string = typeof window !== "undefined" ? window.location.origin : ""
+): string | null {
+  const encoded = encodeShareState(state);
+  if (!encoded || !origin) return null;
+  return `${origin}?s=${encodeURIComponent(encoded)}`;
+}
+
+export function decodeShareState<T = unknown>(s: string): T | null {
   try {
     const raw = decompressFromEncodedURIComponent(s);
     return raw ? (JSON.parse(raw) as T) : null;

--- a/types/types.ts
+++ b/types/types.ts
@@ -1,6 +1,9 @@
 export type Mode = "monaco" | "codemirror";
 
 export type AspectPreset = "3:2" | "4:3" | "16:9";
+export type ExportFormat = "svg" | "png" | "jpg";
+export type ExportAspectOption = "original" | AspectPreset;
+
 export const ASPECT_MAP: Record<AspectPreset, number> = {
   "3:2": 3 / 2,
   "4:3": 4 / 3,


### PR DESCRIPTION
## 변경 요약
공유 링크 생성 흐름을 비동기 처리로 정리하고, clipboard API 실패 시 fallback 경로를 거치도록 보강했습니다.
기존의 blocking `alert` 대신 버튼 상태와 메시지로 피드백이 보이도록 바꾸어 사용 흐름을 덜 끊도록 했습니다.
또한 잘못된 공유 파라미터가 들어와도 앱이 깨지지 않도록 예외 처리를 보완했습니다.

## 직접 테스트 가능 여부
가능

## 확인한 사항
| 항목 | 상태 |
| --- | --- |
| `git diff --check` | 통과 |
| 개발 환경 수동 확인 시나리오 | 아래 정리 |

## 테스트 시나리오
1. 기본 공유 링크 복사
코드와 옵션을 적당히 변경한 뒤 `Share Link` 버튼을 누릅니다.
복사 완료 메시지와 브라우저 주소창 결과를 확인합니다.
기대 결과:
- blocking `alert` 없이 완료 피드백이 표시됩니다.
- 복사된 URL에 `?s=` 파라미터가 포함됩니다.

2. 공유 링크 복원 확인
복사된 URL을 새 탭에 열어 봅니다.
코드, theme, 배경색, scale 등 상태가 복원되는지 확인합니다.
기대 결과:
- 공유 시점의 상태가 정상적으로 다시 적용됩니다.

3. 연속 클릭 확인
`Share Link` 버튼을 짧은 시간 안에 여러 번 눌러 봅니다.
기대 결과:
- 버튼이 busy/disabled 상태를 적절히 표시합니다.
- 중복 처리 때문에 UI가 깨지거나 여러 alert가 뜨지 않습니다.

4. clipboard fallback 확인
브라우저 권한이나 환경상 clipboard API가 막힌 상태를 가정합니다.
그 상태에서 `Share Link`를 눌러 봅니다.
기대 결과:
- 앱이 중단되지 않고 fallback 경로로 복사를 시도합니다.
- 실패하더라도 사용자가 이해할 수 있는 메시지가 보입니다.

5. 잘못된 `?s=` 파라미터 확인
주소창에 `?s=invalid` 같은 잘못된 값을 넣고 페이지를 엽니다.
기대 결과:
- 앱이 깨지지 않고 기본 상태로 안전하게 동작합니다.

## 참고
이 PR은 공유 흐름 안정화가 목적이며, 별도의 성능 비교 측정은 필요하지 않습니다.