### PR TITLE
fix: stop mermaid syntax errors leaking below preview

### DIFF
--- a/components/MermaidPreview.tsx
+++ b/components/MermaidPreview.tsx
@@ -162,10 +162,16 @@ export default function MermaidPreview({
           startOnLoad: false,
           theme: resolvedTheme,
           securityLevel: "strict",
+          suppressErrorRendering: true,
           fontFamily: "Inter, Pretendard, system-ui, sans-serif",
         });
+        mermaid.setParseErrorHandler?.(() => undefined);
 
-        const { svg } = await mermaid.render(`m-${renderId}`, trimmedCode);
+        const { svg } = await mermaid.render(
+          `m-${renderId}`,
+          trimmedCode,
+          svgContainerRef.current ?? undefined,
+        );
         if (!cancelled && renderSeqRef.current === renderId) {
           const exportableSvg = svg.trim();
           setRawSvg(exportableSvg);

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "zustand": "^5.0.8"
       },
       "devDependencies": {
-        "@biomejs/biome": "2.4.7",
+        "@biomejs/biome": "2.4.8",
         "@tailwindcss/postcss": "^4.1.14",
         "@types/node": "^25",
         "@types/react": "^19",
@@ -71,9 +71,9 @@
       }
     },
     "node_modules/@biomejs/biome": {
-      "version": "2.4.7",
-      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.7.tgz",
-      "integrity": "sha512-vXrgcmNGZ4lpdwZSpMf1hWw1aWS6B+SyeSYKTLrNsiUsAdSRN0J4d/7mF3ogJFbIwFFSOL3wT92Zzxia/d5/ng==",
+      "version": "2.4.8",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.8.tgz",
+      "integrity": "sha512-ponn0oKOky1oRXBV+rlSaUlixUxf1aZvWC19Z41zBfUOUesthrQqL3OtiAlSB1EjFjyWpn98Q64DHelhA6jNlA==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "bin": {
@@ -87,20 +87,20 @@
         "url": "https://opencollective.com/biome"
       },
       "optionalDependencies": {
-        "@biomejs/cli-darwin-arm64": "2.4.7",
-        "@biomejs/cli-darwin-x64": "2.4.7",
-        "@biomejs/cli-linux-arm64": "2.4.7",
-        "@biomejs/cli-linux-arm64-musl": "2.4.7",
-        "@biomejs/cli-linux-x64": "2.4.7",
-        "@biomejs/cli-linux-x64-musl": "2.4.7",
-        "@biomejs/cli-win32-arm64": "2.4.7",
-        "@biomejs/cli-win32-x64": "2.4.7"
+        "@biomejs/cli-darwin-arm64": "2.4.8",
+        "@biomejs/cli-darwin-x64": "2.4.8",
+        "@biomejs/cli-linux-arm64": "2.4.8",
+        "@biomejs/cli-linux-arm64-musl": "2.4.8",
+        "@biomejs/cli-linux-x64": "2.4.8",
+        "@biomejs/cli-linux-x64-musl": "2.4.8",
+        "@biomejs/cli-win32-arm64": "2.4.8",
+        "@biomejs/cli-win32-x64": "2.4.8"
       }
     },
     "node_modules/@biomejs/cli-darwin-arm64": {
-      "version": "2.4.7",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.7.tgz",
-      "integrity": "sha512-Oo0cF5mHzmvDmTXw8XSjhCia8K6YrZnk7aCS54+/HxyMdZMruMO3nfpDsrlar/EQWe41r1qrwKiCa2QDYHDzWA==",
+      "version": "2.4.8",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.8.tgz",
+      "integrity": "sha512-ARx0tECE8I7S2C2yjnWYLNbBdDoPdq3oyNLhMglmuctThwUsuzFWRKrHmIGwIRWKz0Mat9DuzLEDp52hGnrxGQ==",
       "cpu": [
         "arm64"
       ],
@@ -115,9 +115,9 @@
       }
     },
     "node_modules/@biomejs/cli-darwin-x64": {
-      "version": "2.4.7",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.7.tgz",
-      "integrity": "sha512-I+cOG3sd/7HdFtvDSnF9QQPrWguUH7zrkIMMykM3PtfWU9soTcS2yRb9Myq6MHmzbeCT08D1UmY+BaiMl5CcoQ==",
+      "version": "2.4.8",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.8.tgz",
+      "integrity": "sha512-Jg9/PsB9vDCJlANE8uhG7qDhb5w0Ix69D7XIIc8IfZPUoiPrbLm33k2Ig3NOJ/7nb3UbesFz3D1aDKm9DvzjhQ==",
       "cpu": [
         "x64"
       ],
@@ -132,9 +132,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64": {
-      "version": "2.4.7",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.7.tgz",
-      "integrity": "sha512-om6FugwmibzfP/6ALj5WRDVSND4H2G9X0nkI1HZpp2ySf9lW2j0X68oQSaHEnls6666oy4KDsc5RFjT4m0kV0w==",
+      "version": "2.4.8",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.8.tgz",
+      "integrity": "sha512-5CdrsJct76XG2hpKFwXnEtlT1p+4g4yV+XvvwBpzKsTNLO9c6iLlAxwcae2BJ7ekPGWjNGw9j09T5KGPKKxQig==",
       "cpu": [
         "arm64"
       ],
@@ -149,9 +149,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64-musl": {
-      "version": "2.4.7",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.7.tgz",
-      "integrity": "sha512-I2NvM9KPb09jWml93O2/5WMfNR7Lee5Latag1JThDRMURVhPX74p9UDnyTw3Ae6cE1DgXfw7sqQgX7rkvpc0vw==",
+      "version": "2.4.8",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.8.tgz",
+      "integrity": "sha512-Zo9OhBQDJ3IBGPlqHiTISloo5H0+FBIpemqIJdW/0edJ+gEcLR+MZeZozcUyz3o1nXkVA7++DdRKQT0599j9jA==",
       "cpu": [
         "arm64"
       ],
@@ -166,9 +166,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64": {
-      "version": "2.4.7",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.7.tgz",
-      "integrity": "sha512-bV8/uo2Tj+gumnk4sUdkerWyCPRabaZdv88IpbmDWARQQoA/Q0YaqPz1a+LSEDIL7OfrnPi9Hq1Llz4ZIGyIQQ==",
+      "version": "2.4.8",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.8.tgz",
+      "integrity": "sha512-PdKXspVEaMCQLjtZCn6vfSck/li4KX9KGwSDbZdgIqlrizJ2MnMcE3TvHa2tVfXNmbjMikzcfJpuPWH695yJrw==",
       "cpu": [
         "x64"
       ],
@@ -183,9 +183,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64-musl": {
-      "version": "2.4.7",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.7.tgz",
-      "integrity": "sha512-00kx4YrBMU8374zd2wHuRV5wseh0rom5HqRND+vDldJPrWwQw+mzd/d8byI9hPx926CG+vWzq6AeiT7Yi5y59g==",
+      "version": "2.4.8",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.8.tgz",
+      "integrity": "sha512-Gi8quv8MEuDdKaPFtS2XjEnMqODPsRg6POT6KhoP+VrkNb+T2ywunVB+TvOU0LX1jAZzfBr+3V1mIbBhzAMKvw==",
       "cpu": [
         "x64"
       ],
@@ -200,9 +200,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-arm64": {
-      "version": "2.4.7",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.7.tgz",
-      "integrity": "sha512-hOUHBMlFCvDhu3WCq6vaBoG0dp0LkWxSEnEEsxxXvOa9TfT6ZBnbh72A/xBM7CBYB7WgwqboetzFEVDnMxelyw==",
+      "version": "2.4.8",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.8.tgz",
+      "integrity": "sha512-LoFatS0tnHv6KkCVpIy3qZCih+MxUMvdYiPWLHRri7mhi2vyOOs8OrbZBcLTUEWCS+ktO72nZMy4F96oMhkOHQ==",
       "cpu": [
         "arm64"
       ],
@@ -217,9 +217,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-x64": {
-      "version": "2.4.7",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.7.tgz",
-      "integrity": "sha512-qEpGjSkPC3qX4ycbMUthXvi9CkRq7kZpkqMY1OyhmYlYLnANnooDQ7hDerM8+0NJ+DZKVnsIc07h30XOpt7LtQ==",
+      "version": "2.4.8",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.8.tgz",
+      "integrity": "sha512-vAn7iXDoUbqFXqVocuq1sMYAd33p8+mmurqJkWl6CtIhobd/O6moe4rY5AJvzbunn/qZCdiDVcveqtkFh1e7Hg==",
       "cpu": [
         "x64"
       ],


### PR DESCRIPTION
## 요약
- Mermaid 기본 에러 렌더링을 끄고 앱의 인라인 에러 SVG만 사용하도록 변경했습니다.
- Mermaid 렌더 타깃을 preview 컨테이너로 고정하고 render id를 안정화했습니다.
- syntax 오류가 나도 화면 하단에 Mermaid 오류 DOM이 새지 않도록 막았습니다.

## 검증
- `./node_modules/.bin/biome.cmd check components/MermaidPreview.tsx`
- `npm run build`